### PR TITLE
Fix misc bugs and update UI with icons for visualizations

### DIFF
--- a/src/lib/components/AppNavbar.svelte
+++ b/src/lib/components/AppNavbar.svelte
@@ -196,8 +196,7 @@
 	);
 
 	let hasActiveSettings = $derived(
-		(activePanelKey === 'dashboard' && dashboardOptionsByPanel.length > 0) ||
-			(!!activePanelKey && !!panelOptionsMap[activePanelKey])
+		(activePanelKey === 'dashboard' && dashboardOptionsByPanel.length > 0) || (!!activePanelKey && !!panelOptionsMap[activePanelKey])
 	);
 
 	// --- Functions ---

--- a/src/lib/components/AppNavbar.svelte
+++ b/src/lib/components/AppNavbar.svelte
@@ -174,10 +174,7 @@
 
 	// --- Derived state ---
 
-	let activePanelKey = $derived.by(() => {
-		const activeToggle = techniqueToggleOptions.find((t) => $ConfigStore[t]);
-		return activeToggle ? activeToggle.replace('Toggle', '') : '';
-	});
+	let activePanelKey = $derived(techniqueToggleOptions.find((t) => $ConfigStore[t])?.replace('Toggle', '') ?? '');
 
 	let activeVisualizationName = $derived(activePanelKey ? (PANEL_LABELS[activePanelKey] ?? 'Dashboard') : 'Select');
 	let ActiveVizIcon = $derived(TILE_INFO[activePanelKey]?.icon ?? LayoutDashboard);
@@ -202,12 +199,16 @@
 	// --- Functions ---
 
 	function formatToggleName(toggle: string) {
-		if (toggle === 'dashboardToggle') return 'Dashboard';
 		return PANEL_LABELS[toggle.replace('Toggle', '')] ?? toggle;
 	}
 
 	function isOptionVisible(option: PanelOption): boolean {
 		return option.type !== 'slider' || !hiddenSliderKeys.has(option.key);
+	}
+
+	function sliderLabel(option: PanelSlider): string {
+		const value = $ConfigStore[option.key] as number;
+		return `${option.label}: ${option.formatValue ? option.formatValue(value) : value}`;
 	}
 
 	function toggleSelection(selection: string, toggleOptions: readonly (keyof ConfigStoreType)[]) {
@@ -292,7 +293,7 @@
 				<span class="truncate">{selectedExample || 'Examples'}</span>
 				<ChevronDown size={12} class="ml-2 flex-shrink-0" />
 			</summary>
-			<ul class="menu dropdown-content rounded-box z-[1] w-56 p-2 shadow bg-base-100 max-h-[60vh] overflow-y-auto overflow-x-hidden">
+			<ul class="menu dropdown-content rounded-box z-[60] w-56 p-2 shadow bg-base-100 max-h-[60vh] overflow-y-auto overflow-x-hidden">
 				{#each exampleOptions as item}
 					{@const Icon = item.icon}
 					<li class="w-full">
@@ -333,12 +334,9 @@
 									{option.label}
 								</button>
 							{:else if option.type === 'slider'}
-								<div class="py-1 px-1">
-									<label for={option.key} class="text-sm text-gray-600"
-										>{option.label}: {option.formatValue ? option.formatValue($ConfigStore[option.key] as number) : $ConfigStore[option.key]}</label
-									>
+								<label class="block py-1 px-1">
+									<span class="text-sm text-gray-600">{sliderLabel(option)}</span>
 									<input
-										id={option.key}
 										type="range"
 										min={option.min}
 										max={option.max}
@@ -346,7 +344,7 @@
 										class="range range-sm w-full"
 										oninput={(e) => handleConfigChangeFromInput(e, option.key)}
 									/>
-								</div>
+								</label>
 							{:else if option.type === 'speakerSort'}
 								<div class="py-1 px-1">
 									<p class="text-sm text-gray-600">Sort By</p>
@@ -574,12 +572,9 @@
 								{option.label}
 							</button>
 						{:else if option.type === 'slider'}
-							<div class="w-full mt-1">
-								<label for={option.key} class="text-sm"
-									>{option.label}: {option.formatValue ? option.formatValue($ConfigStore[option.key] as number) : $ConfigStore[option.key]}</label
-								>
+							<label class="w-full mt-1 block">
+								<span class="text-sm">{sliderLabel(option)}</span>
 								<input
-									id={option.key}
 									type="range"
 									min={option.min}
 									max={option.max}
@@ -587,7 +582,7 @@
 									class="range range-sm w-full"
 									oninput={(e) => handleConfigChangeFromInput(e, option.key)}
 								/>
-							</div>
+							</label>
 						{:else if option.type === 'speakerSort'}
 							<p class="text-sm text-gray-600">Sort By</p>
 							<div class="flex flex-wrap gap-1 w-full">

--- a/src/lib/components/AppNavbar.svelte
+++ b/src/lib/components/AppNavbar.svelte
@@ -19,7 +19,7 @@
 		Settings2
 	} from '@lucide/svelte';
 	import IconButton from './IconButton.svelte';
-	import ConfigStore, { type ConfigStoreType, type GardenSortOrder } from '../../stores/configStore';
+	import ConfigStore, { type ConfigStoreType, type SpeakerSortOrder } from '../../stores/configStore';
 
 	interface Props {
 		selectedExample?: string;
@@ -97,7 +97,7 @@
 		wordJourney: 'Word Journey'
 	};
 
-	const GARDEN_SORT_OPTIONS: { order: GardenSortOrder; label: string }[] = [
+	const SPEAKER_SORT_OPTIONS: { order: SpeakerSortOrder; label: string }[] = [
 		{ order: 'default', label: 'Appearance' },
 		{ order: 'words', label: 'Word Count' },
 		{ order: 'turns', label: 'Turn Count' },
@@ -108,13 +108,13 @@
 
 	type PanelToggle = { type: 'toggle'; key: keyof ConfigStoreType; label: string };
 	type PanelSlider = { type: 'slider'; key: keyof ConfigStoreType; label: string; min: number; max: number; formatValue?: (v: number) => string };
-	type PanelGardenSort = { type: 'gardenSort' };
-	type PanelOption = PanelToggle | PanelSlider | PanelGardenSort;
+	type PanelSpeakerSort = { type: 'speakerSort' };
+	type PanelOption = PanelToggle | PanelSlider | PanelSpeakerSort;
 
 	const formatBinCount = (v: number) => (v === 0 ? 'Auto' : String(v));
 
 	const panelOptionsMap: Record<string, PanelOption[]> = {
-		speakerGarden: [{ type: 'gardenSort' }],
+		speakerGarden: [{ type: 'speakerSort' }],
 		turnChart: [
 			{ type: 'toggle', key: 'separateToggle', label: 'Group by Speaker' },
 			{ type: 'toggle', key: 'silenceOverlapToggle', label: 'Silence Overlap' }
@@ -134,6 +134,7 @@
 			{ type: 'slider', key: 'wordRainBinCount', label: 'Bin Count', min: 4, max: 20 }
 		],
 		turnNetwork: [
+			{ type: 'speakerSort' },
 			{ type: 'toggle', key: 'turnNetworkHideSelfLoops', label: 'Hide Self-Loops' },
 			{ type: 'toggle', key: 'turnNetworkWeightByWords', label: 'Weight by Words' },
 			{ type: 'slider', key: 'turnNetworkMinTransitions', label: 'Min Transitions', min: 1, max: 20 }
@@ -194,8 +195,8 @@
 		ConfigStore.update((store) => ({ ...store, [selection]: !store[selection] }));
 	}
 
-	function setGardenSort(order: GardenSortOrder) {
-		ConfigStore.update((store) => ({ ...store, gardenSortOrder: order }));
+	function setSpeakerSort(order: SpeakerSortOrder) {
+		ConfigStore.update((store) => ({ ...store, speakerSortOrder: order }));
 	}
 
 	function handleConfigChangeFromInput(e: Event, key: keyof ConfigStoreType) {
@@ -389,21 +390,22 @@
 											oninput={(e) => handleConfigChangeFromInput(e, option.key)}
 										/>
 									</div>
-								{:else if option.type === 'gardenSort'}
+								{:else if option.type === 'speakerSort'}
 									<div class="py-1 px-1">
 										<label class="text-sm text-gray-600">Sort By</label>
 									</div>
-									{#each GARDEN_SORT_OPTIONS as sortOpt}
+									{#each SPEAKER_SORT_OPTIONS as sortOpt}
 										<button
-											onclick={() => setGardenSort(sortOpt.order)}
+											onclick={() => setSpeakerSort(sortOpt.order)}
 											class="w-full text-left flex items-center text-sm py-1 px-1 rounded hover:bg-base-200"
 										>
 											<span class="w-4 h-4 mr-2 inline-flex items-center justify-center flex-shrink-0">
-												{#if $ConfigStore.gardenSortOrder === sortOpt.order}<Check size={14} />{/if}
+												{#if $ConfigStore.speakerSortOrder === sortOpt.order}<Check size={14} />{/if}
 											</span>
 											{sortOpt.label}
 										</button>
 									{/each}
+									<hr class="my-1 border-t border-gray-200" />
 								{/if}
 							{/if}
 						{/each}
@@ -572,18 +574,19 @@
 									oninput={(e) => handleConfigChangeFromInput(e, option.key)}
 								/>
 							</div>
-						{:else if option.type === 'gardenSort'}
+						{:else if option.type === 'speakerSort'}
 							<label class="text-sm text-gray-600">Sort By</label>
 							<div class="flex flex-wrap gap-1 w-full">
-								{#each GARDEN_SORT_OPTIONS as sortOpt}
+								{#each SPEAKER_SORT_OPTIONS as sortOpt}
 									<button
-										class="btn btn-xs {$ConfigStore.gardenSortOrder === sortOpt.order ? 'btn-primary' : 'btn-ghost'}"
-										onclick={() => setGardenSort(sortOpt.order)}
+										class="btn btn-xs {$ConfigStore.speakerSortOrder === sortOpt.order ? 'btn-primary' : 'btn-ghost'}"
+										onclick={() => setSpeakerSort(sortOpt.order)}
 									>
 										{sortOpt.label}
 									</button>
 								{/each}
 							</div>
+							<hr class="my-1 border-t border-gray-200" />
 						{/if}
 					{/if}
 				{/each}

--- a/src/lib/components/AppNavbar.svelte
+++ b/src/lib/components/AppNavbar.svelte
@@ -69,6 +69,7 @@
 
 	let mobileMenuOpen = $state(false);
 	let vizDropdownOpen = $state(false);
+	let settingsPanelOpen = $state(false);
 
 	// --- Data ---
 
@@ -189,11 +190,11 @@
 		return hidden;
 	});
 
-	let dashboardOptionsByPanel = $derived.by(() => {
-		return $ConfigStore.dashboardPanels
+	let dashboardOptionsByPanel = $derived(
+		$ConfigStore.dashboardPanels
 			.filter((key) => key in panelOptionsMap)
-			.map((key) => ({ key, label: PANEL_LABELS[key] ?? key, options: panelOptionsMap[key] }));
-	});
+			.map((key) => ({ key, label: PANEL_LABELS[key] ?? key, options: panelOptionsMap[key] }))
+	);
 
 	let hasActiveSettings = $derived(
 		(activePanelKey === 'dashboard' && dashboardOptionsByPanel.length > 0) ||
@@ -256,7 +257,10 @@
 	}
 
 	function clickOutsideViz(node: HTMLElement) {
-		return clickOutsideAction(node, () => (vizDropdownOpen = false));
+		return clickOutsideAction(node, () => {
+			vizDropdownOpen = false;
+			settingsPanelOpen = false;
+		});
 	}
 
 	function clickOutside(node: HTMLElement) {
@@ -400,10 +404,22 @@
 								Dashboard
 							</button>
 						</div>
+
+						{#if hasActiveSettings}
+							<hr class="my-2.5 border-t border-gray-200" />
+							<button
+								class="w-full flex items-center gap-2 px-1 py-1.5 text-sm rounded hover:bg-gray-100 transition-colors
+									{settingsPanelOpen ? 'text-primary' : 'text-gray-500'}"
+								onclick={() => (settingsPanelOpen = !settingsPanelOpen)}
+							>
+								<SettingsIcon size={14} />
+								<span class="truncate">{activeVisualizationName} Settings</span>
+							</button>
+						{/if}
 					</div>
 
 					<!-- Settings side panel -->
-					{#if hasActiveSettings}
+					{#if hasActiveSettings && settingsPanelOpen}
 						<div class="rounded-lg w-52 py-3 px-3 shadow-lg bg-base-100 border border-gray-200 max-h-[70vh] overflow-y-auto">
 							{#if activePanelKey === 'dashboard'}
 								<p class="text-[10px] uppercase tracking-widest text-gray-400 font-semibold mb-2">Dashboard</p>

--- a/src/lib/components/AppNavbar.svelte
+++ b/src/lib/components/AppNavbar.svelte
@@ -371,10 +371,22 @@
 
 				<div class="absolute top-full left-0 mt-1 z-[1] flex items-start gap-1">
 					<!-- Grid panel -->
-					<div class="rounded-lg w-72 py-3 px-3 shadow-lg bg-base-100 border border-gray-200">
+					<div class="rounded-lg w-80 py-3 px-3 shadow-lg bg-base-100 border border-gray-200">
+						{#if hasActiveSettings}
+							<button
+								class="w-full flex items-center gap-2 px-1 py-1.5 mb-2.5 text-sm rounded hover:bg-gray-100 transition-colors
+									{settingsPanelOpen ? 'text-primary' : 'text-gray-500'}"
+								onclick={() => (settingsPanelOpen = !settingsPanelOpen)}
+							>
+								<SettingsIcon size={14} />
+								<span class="truncate">{activeVisualizationName} Settings</span>
+							</button>
+							<hr class="mb-2.5 border-t border-gray-200" />
+						{/if}
+
 						{#each vizCategories as category, ci}
 							<p class="text-[10px] uppercase tracking-widest text-gray-400 font-semibold mb-1.5 {ci > 0 ? 'mt-3' : ''}">{category.label}</p>
-							<div class="grid grid-cols-3 gap-1.5">
+							<div class="grid grid-cols-4 gap-1.5">
 								{#each category.items as toggle}
 									{@const panelKey = toggle.replace('Toggle', '')}
 									{@const isActive = $ConfigStore[toggle]}
@@ -394,7 +406,7 @@
 						{/each}
 
 						<hr class="my-2.5 border-t border-gray-200" />
-						<div class="grid grid-cols-3 gap-1.5">
+						<div class="grid grid-cols-4 gap-1.5">
 							<button
 								class="flex flex-col items-center gap-1 rounded-lg px-2 py-2 text-xs cursor-pointer transition-colors
 									{$ConfigStore.dashboardToggle ? 'bg-primary/10 text-primary ring-1 ring-primary/30 font-medium' : 'text-gray-600 hover:bg-gray-100'}"
@@ -404,18 +416,6 @@
 								Dashboard
 							</button>
 						</div>
-
-						{#if hasActiveSettings}
-							<hr class="my-2.5 border-t border-gray-200" />
-							<button
-								class="w-full flex items-center gap-2 px-1 py-1.5 text-sm rounded hover:bg-gray-100 transition-colors
-									{settingsPanelOpen ? 'text-primary' : 'text-gray-500'}"
-								onclick={() => (settingsPanelOpen = !settingsPanelOpen)}
-							>
-								<SettingsIcon size={14} />
-								<span class="truncate">{activeVisualizationName} Settings</span>
-							</button>
-						{/if}
 					</div>
 
 					<!-- Settings side panel -->

--- a/src/lib/components/AppNavbar.svelte
+++ b/src/lib/components/AppNavbar.svelte
@@ -8,7 +8,6 @@
 		Check,
 		Settings as SettingsIcon,
 		Text,
-		ChartBar,
 		Menu,
 		X,
 		Keyboard,
@@ -182,6 +181,7 @@
 	});
 
 	let activeVisualizationName = $derived(activePanelKey ? (PANEL_LABELS[activePanelKey] ?? 'Dashboard') : 'Select');
+	let ActiveVizIcon = $derived(TILE_INFO[activePanelKey]?.icon ?? LayoutDashboard);
 
 	let hiddenSliderKeys = $derived.by(() => {
 		const hidden = new Set<keyof ConfigStoreType>();
@@ -315,7 +315,7 @@
 		<!-- Visualization Grid Popover -->
 		<div class="relative" use:clickOutsideViz data-tour="viz-modes">
 			<button class="btn btn-sm gap-1 flex items-center" title={activeVisualizationName} onclick={() => (vizDropdownOpen = !vizDropdownOpen)}>
-				<ChartBar size={16} />
+				<ActiveVizIcon size={16} />
 				<span class="max-w-[6rem] truncate">{activeVisualizationName}</span>
 				<ChevronDown size={12} class="flex-shrink-0" />
 			</button>

--- a/src/lib/components/AppNavbar.svelte
+++ b/src/lib/components/AppNavbar.svelte
@@ -325,7 +325,7 @@
 							{#if option.type === 'toggle'}
 								<button
 									onclick={() => toggleSelectionOnly(option.key)}
-									class="w-full text-left flex items-center text-sm py-1 px-1 rounded hover:bg-base-200"
+									class="w-full text-left flex items-center text-sm py-1 px-1 rounded hover:bg-base-200 cursor-pointer"
 								>
 									<span class="w-4 h-4 mr-2 inline-flex items-center justify-center flex-shrink-0">
 										{#if $ConfigStore[option.key]}<Check size={14} />{/if}
@@ -354,7 +354,7 @@
 								{#each SPEAKER_SORT_OPTIONS as sortOpt}
 									<button
 										onclick={() => setSpeakerSort(sortOpt.order)}
-										class="w-full text-left flex items-center text-sm py-1 px-1 rounded hover:bg-base-200"
+										class="w-full text-left flex items-center text-sm py-1 px-1 rounded hover:bg-base-200 cursor-pointer"
 									>
 										<span class="w-4 h-4 mr-2 inline-flex items-center justify-center flex-shrink-0">
 											{#if $ConfigStore.speakerSortOrder === sortOpt.order}<Check size={14} />{/if}
@@ -368,12 +368,12 @@
 					{/each}
 				{/snippet}
 
-				<div class="absolute top-full left-0 mt-1 z-[1] flex items-start gap-1">
+				<div class="absolute top-full left-0 mt-1 z-[60] flex items-start gap-1">
 					<!-- Grid panel -->
 					<div class="rounded-lg w-80 py-3 px-3 shadow-lg bg-base-100 border border-gray-200">
 						{#if hasActiveSettings}
 							<button
-								class="w-full flex items-center gap-2 px-1 py-1.5 mb-2.5 text-sm rounded hover:bg-gray-100 transition-colors
+								class="w-full flex items-center gap-2 px-1 py-1.5 mb-2.5 text-sm rounded hover:bg-gray-100 transition-colors cursor-pointer
 									{settingsPanelOpen ? 'text-primary' : 'text-gray-500'}"
 								onclick={() => (settingsPanelOpen = !settingsPanelOpen)}
 							>

--- a/src/lib/components/DashboardOverlay.svelte
+++ b/src/lib/components/DashboardOverlay.svelte
@@ -48,6 +48,18 @@
 
 	let count = $derived($ConfigStore.dashboardPanels.length);
 	let openPopoverIndex = $state<number | null>(null);
+	let panelRefs: HTMLElement[] = $state([]);
+
+	$effect(() => {
+		if (openPopoverIndex === null) return;
+		const handleClick = (event: MouseEvent) => {
+			if (!panelRefs[openPopoverIndex!]?.contains(event.target as Node)) {
+				openPopoverIndex = null;
+			}
+		};
+		document.addEventListener('click', handleClick, true);
+		return () => document.removeEventListener('click', handleClick, true);
+	});
 
 	function selectViz(index: number, key: string) {
 		ConfigStore.update((store) => {
@@ -89,7 +101,7 @@
 	{#each $ConfigStore.dashboardPanels as panelKey, i}
 		{@const info = PANEL_ICONS[panelKey]}
 		<div class="panel-cell" class:span-two={count === 3 && i === 0}>
-			<div class="relative flex justify-end pointer-events-auto">
+			<div class="relative flex justify-end pointer-events-auto" bind:this={panelRefs[i]}>
 				<!-- Icon trigger -->
 				<button
 					class="p-1.5 rounded-md bg-white/70 hover:bg-white/90 border border-gray-300 shadow-sm transition-colors"
@@ -125,11 +137,6 @@
 		</div>
 	{/each}
 </div>
-
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-{#if openPopoverIndex !== null}
-	<div class="fixed inset-0 z-[49]" onclick={() => (openPopoverIndex = null)} onkeydown={() => {}}></div>
-{/if}
 
 <style>
 	.dashboard-overlay {

--- a/src/lib/components/DashboardOverlay.svelte
+++ b/src/lib/components/DashboardOverlay.svelte
@@ -1,15 +1,34 @@
 <script lang="ts">
 	import ConfigStore, { DASHBOARD_PANEL_OPTIONS } from '../../stores/configStore';
-	import { Minus, Plus } from '@lucide/svelte';
+	import type { Component } from 'svelte';
+	import {
+		Minus,
+		Plus,
+		Flower2,
+		Grid3x3,
+		Fingerprint,
+		ChartNoAxesGantt,
+		ChartBarStacked,
+		ChartNetwork,
+		MessageCircleQuestionMark,
+		Cloud,
+		CloudRain,
+		Route
+	} from '@lucide/svelte';
 	import { CANVAS_SPACING } from '../constants/ui';
 
-	function setPanelViz(index: number, key: string) {
-		ConfigStore.update((store) => {
-			const panels = [...store.dashboardPanels];
-			panels[index] = key;
-			return { ...store, dashboardPanels: panels };
-		});
-	}
+	const PANEL_ICONS: Record<string, { label: string; icon: Component }> = {
+		speakerGarden: { label: 'Garden', icon: Flower2 },
+		speakerHeatmap: { label: 'Heatmap', icon: Grid3x3 },
+		speakerFingerprint: { label: 'Fingerprint', icon: Fingerprint },
+		turnChart: { label: 'Chart', icon: ChartNoAxesGantt },
+		turnLength: { label: 'Length', icon: ChartBarStacked },
+		turnNetwork: { label: 'Network', icon: ChartNetwork },
+		questionFlow: { label: 'Question', icon: MessageCircleQuestionMark },
+		contributionCloud: { label: 'Cloud', icon: Cloud },
+		wordRain: { label: 'Rain', icon: CloudRain },
+		wordJourney: { label: 'Journey', icon: Route }
+	};
 
 	function addPanel() {
 		ConfigStore.update((store) => {
@@ -28,6 +47,16 @@
 	}
 
 	let count = $derived($ConfigStore.dashboardPanels.length);
+	let openPopoverIndex = $state<number | null>(null);
+
+	function selectViz(index: number, key: string) {
+		ConfigStore.update((store) => {
+			const panels = [...store.dashboardPanels];
+			panels[index] = key;
+			return { ...store, dashboardPanels: panels };
+		});
+		openPopoverIndex = null;
+	}
 </script>
 
 <div
@@ -38,7 +67,7 @@
 	style:padding="{CANVAS_SPACING / 2}px"
 	style:gap="{CANVAS_SPACING}px"
 >
-	<div class="absolute top-2 right-2 pointer-events-auto flex gap-0.5 z-[51]">
+	<div class="absolute top-2 left-2 pointer-events-auto flex gap-0.5 z-[51]">
 		<button
 			class="btn btn-xs btn-ghost bg-white/70 hover:bg-white/90 border border-gray-300 shadow-sm"
 			onclick={removePanel}
@@ -58,19 +87,49 @@
 	</div>
 
 	{#each $ConfigStore.dashboardPanels as panelKey, i}
+		{@const info = PANEL_ICONS[panelKey]}
 		<div class="panel-cell" class:span-two={count === 3 && i === 0}>
-			<select
-				class="select select-bordered select-xs bg-white/70 hover:bg-white/90 focus:bg-white shadow-sm text-xs pointer-events-auto"
-				value={panelKey}
-				onchange={(e) => setPanelViz(i, e.currentTarget.value)}
-			>
-				{#each DASHBOARD_PANEL_OPTIONS as option}
-					<option value={option.key} disabled={$ConfigStore.dashboardPanels.some((k, j) => j !== i && k === option.key)}>{option.label}</option>
-				{/each}
-			</select>
+			<div class="relative flex justify-end pointer-events-auto">
+				<!-- Icon trigger -->
+				<button
+					class="p-1.5 rounded-md bg-white/70 hover:bg-white/90 border border-gray-300 shadow-sm transition-colors"
+					onclick={() => (openPopoverIndex = openPopoverIndex === i ? null : i)}
+					title={info.label}
+				>
+					<info.icon size={14} strokeWidth={1.5} class="text-gray-600" />
+				</button>
+
+				<!-- Icon grid popover -->
+				{#if openPopoverIndex === i}
+					<div class="absolute top-full right-0 mt-1 z-[52] rounded-lg py-2 px-2 shadow-lg bg-base-100 border border-gray-200 w-44">
+						<div class="grid grid-cols-3 gap-1">
+							{#each DASHBOARD_PANEL_OPTIONS as option}
+								{@const tile = PANEL_ICONS[option.key]}
+								{@const isActive = panelKey === option.key}
+								{@const isUsed = $ConfigStore.dashboardPanels.some((k, j) => j !== i && k === option.key)}
+								<button
+									class="flex flex-col items-center gap-0.5 rounded-md px-1 py-1.5 text-[10px] cursor-pointer transition-colors
+										{isActive ? 'bg-primary/10 text-primary ring-1 ring-primary/30 font-medium' : isUsed ? 'text-gray-300 cursor-not-allowed' : 'text-gray-600 hover:bg-gray-100'}"
+									onclick={() => selectViz(i, option.key)}
+									disabled={isUsed}
+									title={option.label}
+								>
+									<tile.icon size={14} strokeWidth={isActive ? 2.2 : 1.5} />
+									{tile.label}
+								</button>
+							{/each}
+						</div>
+					</div>
+				{/if}
+			</div>
 		</div>
 	{/each}
 </div>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+{#if openPopoverIndex !== null}
+	<div class="fixed inset-0 z-[49]" onclick={() => (openPopoverIndex = null)} onkeydown={() => {}}></div>
+{/if}
 
 <style>
 	.dashboard-overlay {

--- a/src/lib/components/DashboardOverlay.svelte
+++ b/src/lib/components/DashboardOverlay.svelte
@@ -121,7 +121,11 @@
 								{@const isUsed = $ConfigStore.dashboardPanels.some((k, j) => j !== i && k === option.key)}
 								<button
 									class="flex flex-col items-center gap-0.5 rounded-md px-1 py-1.5 text-[10px] cursor-pointer transition-colors
-										{isActive ? 'bg-primary/10 text-primary ring-1 ring-primary/30 font-medium' : isUsed ? 'text-gray-300 cursor-not-allowed' : 'text-gray-600 hover:bg-gray-100'}"
+										{isActive
+										? 'bg-primary/10 text-primary ring-1 ring-primary/30 font-medium'
+										: isUsed
+											? 'text-gray-300 cursor-not-allowed'
+											: 'text-gray-600 hover:bg-gray-100'}"
 									onclick={() => selectViz(i, option.key)}
 									disabled={isUsed}
 									title={option.label}

--- a/src/lib/components/DashboardOverlay.svelte
+++ b/src/lib/components/DashboardOverlay.svelte
@@ -101,10 +101,10 @@
 	{#each $ConfigStore.dashboardPanels as panelKey, i}
 		{@const info = PANEL_ICONS[panelKey]}
 		<div class="panel-cell" class:span-two={count === 3 && i === 0}>
-			<div class="relative flex justify-end pointer-events-auto" bind:this={panelRefs[i]}>
+			<div class="relative flex justify-end" bind:this={panelRefs[i]}>
 				<!-- Icon trigger -->
 				<button
-					class="p-1.5 rounded-md bg-white/70 hover:bg-white/90 border border-gray-300 shadow-sm transition-colors"
+					class="p-1.5 rounded-md bg-white/70 hover:bg-white/90 border border-gray-300 shadow-sm transition-colors pointer-events-auto"
 					onclick={() => (openPopoverIndex = openPopoverIndex === i ? null : i)}
 					title={info.label}
 				>
@@ -113,7 +113,7 @@
 
 				<!-- Icon grid popover -->
 				{#if openPopoverIndex === i}
-					<div class="absolute top-full right-0 mt-1 z-[52] rounded-lg py-2 px-2 shadow-lg bg-base-100 border border-gray-200 w-44">
+					<div class="absolute top-full right-0 mt-1 z-[52] rounded-lg py-2 px-2 shadow-lg bg-base-100 border border-gray-200 w-44 pointer-events-auto">
 						<div class="grid grid-cols-3 gap-1">
 							{#each DASHBOARD_PANEL_OPTIONS as option}
 								{@const tile = PANEL_ICONS[option.key]}

--- a/src/lib/draw/question-flow.ts
+++ b/src/lib/draw/question-flow.ts
@@ -77,8 +77,7 @@ export class QuestionFlow {
 			const searchTerm = normalizeWord(this.config.wordToSearch);
 			pairs = pairs.filter(
 				(p) =>
-					normalizeWord(p.questionContent).includes(searchTerm) ||
-					(p.answerContent != null && normalizeWord(p.answerContent).includes(searchTerm))
+					normalizeWord(p.questionContent).includes(searchTerm) || (p.answerContent != null && normalizeWord(p.answerContent).includes(searchTerm))
 			);
 			if (pairs.length === 0) {
 				this.drawEmptyState();

--- a/src/lib/draw/question-flow.ts
+++ b/src/lib/draw/question-flow.ts
@@ -11,6 +11,7 @@ import type { User } from '../../models/user';
 import type { Bounds } from './types/bounds';
 import type { QuestionAnswerPair } from '../core/dynamic-data';
 import { withDimming, createUserMap, getCrossHighlight, drawTimeAxis } from './draw-utils';
+import { normalizeWord } from '../core/string-utils';
 
 const LEFT_MARGIN = 80;
 const RIGHT_MARGIN = 20;
@@ -69,6 +70,20 @@ export class QuestionFlow {
 		if (pairs.length === 0 || this.speakers.length === 0) {
 			this.drawEmptyState();
 			return { hoveredDataPoint: null, hoveredSpeaker: null };
+		}
+
+		// Filter pairs by search term
+		if (this.config.wordToSearch) {
+			const searchTerm = normalizeWord(this.config.wordToSearch);
+			pairs = pairs.filter(
+				(p) =>
+					normalizeWord(p.questionContent).includes(searchTerm) ||
+					(p.answerContent != null && normalizeWord(p.answerContent).includes(searchTerm))
+			);
+			if (pairs.length === 0) {
+				this.drawEmptyState();
+				return { hoveredDataPoint: null, hoveredSpeaker: null };
+			}
 		}
 
 		// Calculate word counts for sizing

--- a/src/lib/draw/turn-chart.ts
+++ b/src/lib/draw/turn-chart.ts
@@ -333,7 +333,7 @@ export class TurnChart {
 					h: MARKER_HEIGHT,
 					color: OVERLAP_COLOR,
 					firstDataPoint: turns[j].firstDataPoint,
-					tooltipContent: `<b>Overlap · ${formatDuration(duration)}</b>\n<span style="font-size: 0.85em; opacity: 0.7">${turns[i].speaker} & ${turns[j].speaker}\n${formatTimeCompact(start)} - ${formatTimeCompact(end)}</span>`
+					tooltipContent: `<b>Overlap · ${formatDuration(duration)}</b>\n<span style="font-size: 0.85em; opacity: 0.7"><span style="color: ${this.userMap.get(turns[i].speaker)?.user.color ?? '#fff'}">${turns[i].speaker}</span> & <span style="color: ${this.userMap.get(turns[j].speaker)?.user.color ?? '#fff'}">${turns[j].speaker}</span>\n${formatTimeCompact(start)} - ${formatTimeCompact(end)}</span>`
 				});
 			}
 		}
@@ -354,7 +354,7 @@ export class TurnChart {
 				h: MARKER_HEIGHT,
 				color: GAP_COLOR,
 				firstDataPoint: turns[i].firstDataPoint,
-				tooltipContent: `<b>Silence · ${formatDuration(gapDuration)}</b>\n<span style="font-size: 0.85em; opacity: 0.7">${turns[i].speaker} → ${turns[i + 1].speaker}\n${formatTimeCompact(turns[i].endTime)} - ${formatTimeCompact(turns[i + 1].startTime)}</span>`
+				tooltipContent: `<b>Silence · ${formatDuration(gapDuration)}</b>\n<span style="font-size: 0.85em; opacity: 0.7"><span style="color: ${this.userMap.get(turns[i].speaker)?.user.color ?? '#fff'}">${turns[i].speaker}</span> → <span style="color: ${this.userMap.get(turns[i + 1].speaker)?.user.color ?? '#fff'}">${turns[i + 1].speaker}</span>\n${formatTimeCompact(turns[i].endTime)} - ${formatTimeCompact(turns[i + 1].startTime)}</span>`
 			});
 		}
 		return markers;

--- a/src/lib/p5/igsSketch.ts
+++ b/src/lib/p5/igsSketch.ts
@@ -192,10 +192,7 @@ export const igsSketch = (p5: any) => {
 	p5.handleSpeakerFilterClick = () => {
 		if (!editorState?.config?.isVisible) return;
 		const isSpeakerViz =
-			currConfig?.speakerGardenToggle ||
-			currConfig?.speakerFingerprintToggle ||
-			currConfig?.turnNetworkToggle ||
-			currConfig?.dashboardToggle;
+			currConfig?.speakerGardenToggle || currConfig?.speakerFingerprintToggle || currConfig?.turnNetworkToggle || currConfig?.dashboardToggle;
 		if (!isSpeakerViz) return;
 
 		const hoveredSpeaker = hoverState.hoveredSpeaker;

--- a/src/lib/p5/igsSketch.ts
+++ b/src/lib/p5/igsSketch.ts
@@ -188,9 +188,15 @@ export const igsSketch = (p5: any) => {
 		p5.handleVideoClick();
 	};
 
-	// Lock speaker filter in editor when clicking on a speaker's visualization
+	// Lock speaker filter in editor when clicking on a speaker-centric visualization
 	p5.handleSpeakerFilterClick = () => {
 		if (!editorState?.config?.isVisible) return;
+		const isSpeakerViz =
+			currConfig?.speakerGardenToggle ||
+			currConfig?.speakerFingerprintToggle ||
+			currConfig?.turnNetworkToggle ||
+			currConfig?.dashboardToggle;
+		if (!isSpeakerViz) return;
 
 		const hoveredSpeaker = hoverState.hoveredSpeaker;
 		if (hoveredSpeaker) {

--- a/src/stores/configStore.ts
+++ b/src/stores/configStore.ts
@@ -1,6 +1,6 @@
 import { writable, derived } from 'svelte/store';
 
-export type GardenSortOrder = 'default' | 'words' | 'turns' | 'alpha';
+export type SpeakerSortOrder = 'default' | 'words' | 'turns' | 'alpha';
 
 export interface ConfigStoreType {
 	speakerGardenToggle: boolean;
@@ -31,8 +31,8 @@ export interface ConfigStoreType {
 	snippetDurationSeconds: number;
 	// Dashboard panel selection
 	dashboardPanels: string[];
-	// Speaker Garden settings
-	gardenSortOrder: GardenSortOrder;
+	// Speaker sort order (shared across Speaker Garden, Turn Network, etc.)
+	speakerSortOrder: SpeakerSortOrder;
 	// Word Rain settings
 	wordRainMinFrequency: number;
 	wordRainTemporalBinning: boolean;
@@ -93,8 +93,8 @@ export const initialConfig: ConfigStoreType = {
 	speechRateWordsPerSecond: 3,
 	// Video playback settings
 	snippetDurationSeconds: 2,
-	// Speaker Garden settings
-	gardenSortOrder: 'default',
+	// Speaker sort order (used by Speaker Garden, Turn Network, etc.)
+	speakerSortOrder: 'default',
 	// Dashboard panel selection
 	dashboardPanels: ['turnChart', 'contributionCloud', 'speakerGarden'],
 	wordRainMinFrequency: 1,


### PR DESCRIPTION
  - **Visualization selector redesign**: Replace the flat dropdown list with a categorized icon grid (Speaker / Turn / Word) using per-visualization Lucide icons. Settings panel now opens as a side panel alongside the grid instead of a nested
  flyout.
  - **Dashboard overlay**: Replace `<select>` dropdowns with icon grid popovers for panel selection, matching the new navbar style. Move +/- controls to top-left.
  - **Speaker sort generalization**: Rename `gardenSortOrder` → `speakerSortOrder` and share it across Speaker Garden and Turn Network (adds sort option to Turn Network settings).
  - **Search filtering**: Add word search support to Question Flow and Speaker Fingerprint visualizations, filtering displayed data by the search term.
  - **Silence/overlap speaker colors**: Color speaker names in Turn Chart silence/overlap tooltips with their assigned colors.
  - **Editor click filter**: Restrict speaker-highlight-on-click in the editor to speaker-centric visualizations only (Garden, Fingerprint, Turn Network, Dashboard).
  - **Text parser fix**: Simplify forced-format parsing logic and fix line splitting to handle `\r` line endings.
  - **UI cleanup**: Generalize `clickOutside` action, add aria-labels, constrain example dropdown width, replace inline SVG chevrons with Lucide `ChevronDown`.